### PR TITLE
Enable selection of Microsoft Graph endpoints

### DIFF
--- a/roadlib/roadtools/roadlib/constants.py
+++ b/roadlib/roadtools/roadlib/constants.py
@@ -3,7 +3,9 @@ Constants for roadlib containing well-known resources, login templates (xml), et
 """
 
 WELLKNOWN_RESOURCES = {
-    "msgraph": "https://graph.microsoft.us/",
+    "msgraph": "https://graph.microsoft.com/",
+    "msgraph-us": "https://graph.microsoft.us/",
+    "msgraph-com": "https://graph.microsoft.com/",
     "aadgraph": "https://graph.windows.net/",
     "devicereg": "urn:ms-drs:enterpriseregistration.windows.net",
     "drs": "urn:ms-drs:enterpriseregistration.windows.net",

--- a/roadtx/roadtools/roadtx/main.py
+++ b/roadtx/roadtools/roadtx/main.py
@@ -518,7 +518,7 @@ def main():
 
     # Find scope
     getscope_parser = subparsers.add_parser('getscope', aliases=['findscope'], help='Find first-party apps with the right pre-approved scope')
-    getscope_parser.add_argument('-s', '--scope', default=None, action='store', required=False, metavar='SCOPE', help='Desired scope (API URL + scope on that API, for example https://graph.microsoft.us/files.read).')
+    getscope_parser.add_argument('-s', '--scope', default=None, action='store', required=False, metavar='SCOPE', help='Desired scope (API URL + scope on that API, for example https://graph.microsoft.com/files.read).')
     getscope_parser.add_argument('-a', '--all', action='store_true', help='List all scopes instead')
     getscope_parser.add_argument('--foci', action='store_true', help='Only list FOCI clients')
     getscope_parser.add_argument('--all-clients', action='store_true', help='List all clients instead of public clients only (may require advanced auth flow to use)')
@@ -1349,7 +1349,7 @@ def main():
         print('Well-known resources. Can be used as alias with -r or --resource')
         print()
         for alias, resourceurl in WELLKNOWN_RESOURCES.items():
-            print(f"{alias:<10} - {resourceurl}")
+            print(f"{alias:<12} - {resourceurl}")
         print()
         print('Well-known user agents. Can be used as alias with -ua or --user-agent')
         print()
@@ -1748,7 +1748,7 @@ def main():
             resource, scope = args.scope.lower().rsplit('/', 1)
         except ValueError:
             print("No resource (API) specified in scope, defaulting to Microsoft Graph")
-            resource = "https://graph.microsoft.us"
+            resource = "https://graph.microsoft.com"
             scope = args.scope.lower()
 
         try:

--- a/test_aliases.py
+++ b/test_aliases.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python3
+
+import sys
+import os
+
+# Add the roadlib directory to the path
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), 'roadlib'))
+
+from roadtools.roadlib.constants import WELLKNOWN_RESOURCES
+from roadtools.roadlib.auth import Authentication
+
+def test_aliases():
+    print("Testing Microsoft Graph aliases:")
+    print()
+    
+    # Test the aliases
+    aliases_to_test = ['msgraph', 'msgraph-us', 'msgraph-com']
+    
+    for alias in aliases_to_test:
+        if alias in WELLKNOWN_RESOURCES:
+            url = WELLKNOWN_RESOURCES[alias]
+            print(f"{alias:<12} -> {url}")
+        else:
+            print(f"{alias:<12} -> NOT FOUND")
+    
+    print()
+    print("Testing lookup_resource_uri method:")
+    
+    auth = Authentication()
+    for alias in aliases_to_test:
+        resolved = auth.lookup_resource_uri(alias)
+        print(f"{alias:<12} -> {resolved}")
+    
+    print()
+    print("All aliases in WELLKNOWN_RESOURCES:")
+    for alias, url in WELLKNOWN_RESOURCES.items():
+        print(f"{alias:<12} -> {url}")
+
+if __name__ == "__main__":
+    test_aliases()


### PR DESCRIPTION
Add aliases and update defaults to support both Microsoft Graph commercial and US Government endpoints.

Previously, the default Microsoft Graph endpoint and the `msgraph` alias pointed to `graph.microsoft.us`. This PR updates the default `msgraph` alias to `graph.microsoft.com` and introduces explicit aliases (`msgraph-us`, `msgraph-com`) for both, allowing users to choose their target endpoint.